### PR TITLE
feature: Child command contexts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,13 @@ publishing {
                         email = 'jr.marcusorlando@gmail.com'
                     }
                 }
+                contributors {
+                    contributor {
+                        name = "tecc"
+                        email = "tecc@tecc.me"
+                        url = "https://tecc.me"
+                    }
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,17 @@ dependencies {
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'io.papermc.paper:paper-api:1.18.2-R0.1-SNAPSHOT'
 }
 
 java {
     withJavadocJar()
     withSourcesJar()
     toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+}
+
+test {
+    useJUnitPlatform()
 }
 
 publishing {

--- a/src/main/java/com/marcusslover/plus/lib/command/CommandContext.java
+++ b/src/main/java/com/marcusslover/plus/lib/command/CommandContext.java
@@ -4,11 +4,18 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 
 public record CommandContext(@NotNull CommandSender sender, @NotNull String label,
-                             @NotNull String[] args) implements ICommandContextHelper<CommandContext> {
+                             @NotNull String[] args,  @Nullable CommandContext parent) implements ICommandContextHelper<CommandContext> {
+    public CommandContext(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) {
+        this(sender, label, args, null);
+    }
+
     public @NotNull CommandContext asPlayer(@NotNull Consumer<@NotNull Player> player) {
         if (this.sender instanceof Player p) {
             player.accept(p);
@@ -21,5 +28,26 @@ public record CommandContext(@NotNull CommandSender sender, @NotNull String labe
             console.accept(c);
         }
         return this;
+    }
+
+    /**
+     * Creates a child context.
+     * @param consumedArguments The amount of consumed arguments
+     * @return A child context with this context as the parent, the last consumed argument as the label,
+     *         and all unconsumed arguments as args.
+     * @author tecc
+     */
+    public @NotNull CommandContext child(int consumedArguments) {
+        List<String> originalArgs = List.of(this.args());
+        if (originalArgs.size() < 1) {
+            throw new IndexOutOfBoundsException("At least one argument must be available to make a child context");
+        }
+
+        String label = originalArgs.get(consumedArguments - 1);
+        CommandSender sender = this.sender();
+        int remainingArgsLength = originalArgs.size() - consumedArguments;
+        List<String> remainingArgs = remainingArgsLength > 0 ? originalArgs.subList(consumedArguments, originalArgs.size()) : Collections.emptyList();
+
+        return new CommandContext(sender, label, remainingArgs.toArray(new String[0]), this);
     }
 }

--- a/src/test/java/tests/CommandContextTest.java
+++ b/src/test/java/tests/CommandContextTest.java
@@ -1,0 +1,24 @@
+package tests;
+
+import com.marcusslover.plus.lib.command.CommandContext;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+public class CommandContextTest {
+    @SuppressWarnings("DataFlowIssue") // i know that sender can't be null but it doesn't matter here
+    @Test
+    public void childContextTest() {
+        String[] parentArgs = new String[]{"world", "plus"};
+        CommandContext context = new CommandContext(null, "hello", parentArgs);
+        assertEquals(context.parent(), null);
+        assertEquals(context.label(), "hello");
+        assertArrayEquals(context.args(), parentArgs);
+
+        CommandContext child = context.child(1);
+        assertEquals(context, child.parent());
+        assertEquals(child.label(), "world");
+        assertArrayEquals(child.args(), new String[]{parentArgs[1]});
+    }
+}


### PR DESCRIPTION
This simply adds a feature to command contexts allowing the user to create children of the contexts.
It's done very simply:
```java
void someFunction(CommandContext ctx) {
    CommandContext child = ctx.child(2); // consumes 2 arguments - the last consumed argument becomes the label
    // ... more code ...
}
```