### PR TITLE
Get MojangProfile username from the request

### DIFF
--- a/src/main/java/com/marcusslover/plus/lib/mojang/MojangProfileAPI.java
+++ b/src/main/java/com/marcusslover/plus/lib/mojang/MojangProfileAPI.java
@@ -101,7 +101,9 @@ public class MojangProfileAPI {
                 } catch (IllegalArgumentException e) {
                     throw new RuntimeException("Could not parse UUID from Mojang API response", e);
                 }
-
+                if (!json.has("name")) {
+                    throw new RuntimeException("Invalid response from Mojang API");
+                }
                 String name = json.get("name").getAsString();
 
                 // Create the profile

--- a/src/main/java/com/marcusslover/plus/lib/mojang/MojangProfileAPI.java
+++ b/src/main/java/com/marcusslover/plus/lib/mojang/MojangProfileAPI.java
@@ -102,8 +102,10 @@ public class MojangProfileAPI {
                     throw new RuntimeException("Could not parse UUID from Mojang API response", e);
                 }
 
+                String name = json.get("name").getAsString();
+
                 // Create the profile
-                MojangProfile mojangProfile = new MojangProfile(uuid, username, System.currentTimeMillis());
+                MojangProfile mojangProfile = new MojangProfile(uuid, name, System.currentTimeMillis());
 
                 // Cache the profile
                 CACHED_PROFILE_MAP.put(uuid, mojangProfile);


### PR DESCRIPTION
Change MojangProfileAPI to include the name returned from the API Call in the MojangProfile, instead of the username initially entered into the function